### PR TITLE
Feature filter outgoing traffic with UFW_TO and UFW_DENY_OUTGOING labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ To                         Action      From
 443/tcp                    ALLOW       Anywhere
 ```
 
-**Step 7**. Hardening firewall rules with UFW_ALLOW_FROM
+**Step 7**. Hardening firewall rules with UFW_FROM
 
 You can choose to restrict incoming traffic from specific IPs or Subnets.
 For example :
 
 ```
-➜  docker run -d -p 8080:80 -l UFW_MANAGED=TRUE -l "UFW_ALLOW_FROM=192.168.0.2;192.168.1.0/24" nginx:alpine
+➜  docker run -d -p 8080:80 -l UFW_MANAGED=TRUE -l "UFW_FROM=192.168.0.2;192.168.1.0/24" nginx:alpine
 13a6ef724d92f404f150f5796dabfd305f4e16a9de846a67e5e99ba53ed2e4e7
 ```
 
@@ -172,9 +172,9 @@ To                         Action      From
 172.17.0.2 80/tcp          ALLOW FWD   192.168.1.0/24  <= this baby added allowing only 192.168.1.0/24 to access nginx server
 ```
 
-**Step 8**. Hardening firewall rules with UFW_DENY_OUTGOING and UFW_ALLOW_TO
+**Step 8**. Hardening firewall rules with UFW_DENY_OUTGOING and UFW_TO
 
-You can also choose to retrict outgoing traffic from specific IPs, Subnets or hostnames*.
+You can also choose to retrict outgoing traffic from specific IPs, Subnets.
 For example with docker-compose :
 
 ```
@@ -185,9 +185,9 @@ services:
     container_name: nginx
     labels:
       - UFW_MANAGED=true
-      - UFW_ALLOW_FROM=192.168.0.0/24
+      - UFW_FROM=192.168.0.0/24
       - UFW_DENY_OUTGOING=true
-      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24;192.168.3.0/24:tcp
+      - UFW_TO=192.168.1.2;192.168.2.0/24
     ports:
       - 80:80
 ```
@@ -207,19 +207,8 @@ To                         Action      From
 172.17.0.2 80/tcp          ALLOW FWD   192.168.0.0/24     <= this entry allows only 192.168.1.0/24 to access nginx server 
 192.168.0.0/24             ALLOW FWD   172.17.0.2 80/tcp  <= this entry enables nginx server to reply back
 
-53                         ALLOW FWD   172.17.0.2         <= this entry enables nginx to resolve dns queries to any ip
-
-151.101.122.132 80/tcp     ALLOW FWD   172.17.0.2         <= those entries are the result of the commands :
-151.101.192.204 80/tcp     ALLOW FWD   172.17.0.2         <= - 'host -t a deb.debian.org'
-151.101.0.204 80/tcp       ALLOW FWD   172.17.0.2         <= - 'host -t a security.debian.org'
-151.101.64.204 80/tcp      ALLOW FWD   172.17.0.2         <= to enable apt update in the container
-151.101.128.204 80/tcp     ALLOW FWD   172.17.0.2
-
+192.168.1.2                ALLOW FWD   172.17.0.2         <= this entry allow outgoing traffic to 192.168.1.2 ip for all tcp and udp ports
 192.168.2.0/24             ALLOW FWD   172.17.0.2         <= this entry allow outgoing traffic to 192.168.2.0/24 subnet for all tcp and udp ports
-192.168.3.0/24/tcp         ALLOW FWD   172.17.0.2/tcp     <= this entry allow outgoing traffic to 192.168.3.0/24 subnet for all tcp ports
 
 Anywhere                   DENY FWD    172.17.0.2         <= this entry block any other outgoing requests
 ```
-
-*Warning if the hostname changes the IP pool you'll need to restart the container in order to have an updated firewall.
-This is why hostnames provided by dynamic dns will not work.

--- a/README.md
+++ b/README.md
@@ -168,3 +168,54 @@ To                         Action      From
 172.17.0.2 80/tcp          ALLOW FWD   192.168.0.2     <= this baby added allowing only 192.168.0.2 to access nginx server 
 172.17.0.2 80/tcp          ALLOW FWD   192.168.1.0/24  <= this baby added allowing only 192.168.1.0/24 to access nginx server 
 ```
+
+**Step 8**. Hardening firewall rules with UFW_DENY_OUTGOING and UFW_TO
+
+You can also choose to retrict outgoing traffic from specific IPs, Subnets or hostnames*.
+For example with docker-compose :
+
+```
+version: '2.4'
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    labels:
+      - UFW_MANAGED=true
+      - UFW_FROM=192.168.0.0/24
+      - UFW_DENY_OUTGOING=true
+      - UFW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24
+    ports:
+      - 80:80
+```
+
+will add following entry to ufw list.
+
+```
+➜  sudo ufw status
+Status: active
+
+To                         Action      From
+--                         ------      ----
+22                         ALLOW       Anywhere                  
+80/tcp                     ALLOW       Anywhere                  
+443/tcp                    ALLOW       Anywhere                  
+
+172.17.0.2 80/tcp          ALLOW FWD   192.168.0.0/24     <= this entry allows only 192.168.1.0/24 to access nginx server 
+192.168.0.0/24             ALLOW FWD   172.17.0.2 80/tcp  <= this entry enables nginx server to reply back
+
+53                         ALLOW FWD   172.17.0.2         <= this entry enables nginx to resolve dns queries to any ip
+
+151.101.122.132 80/tcp     ALLOW FWD   172.17.0.2         <= those entries are the result of the commands :
+151.101.192.204 80/tcp     ALLOW FWD   172.17.0.2         <= - 'host -t a deb.debian.org'
+151.101.0.204 80/tcp       ALLOW FWD   172.17.0.2         <= - 'host -t a security.debian.org'
+151.101.64.204 80/tcp      ALLOW FWD   172.17.0.2         <= to enable apt update in the container
+151.101.128.204 80/tcp     ALLOW FWD   172.17.0.2
+
+192.168.2.0/24             ALLOW FWD   172.17.0.2         <= this entry allow outgoing traffic to 192.168.2.0/24 subnet for all port tcp and udp
+
+Anywhere                   DENY FWD    172.17.0.2         <= this entry block any other outgoing requests
+```
+
+*Warning if the hostname changes the IP pool you'll need to restart the container in order to have an updated firewall.
+This is why hostnames provided by dynamic dns will not work.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ services:
       - UFW_MANAGED=true
       - UFW_ALLOW_FROM=192.168.0.0/24
       - UFW_DENY_OUTGOING=true
-      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24:tcp
+      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24;192.168.3.0/24:tcp
     ports:
       - 80:80
 ```
@@ -213,7 +213,8 @@ To                         Action      From
 151.101.64.204 80/tcp      ALLOW FWD   172.17.0.2         <= to enable apt update in the container
 151.101.128.204 80/tcp     ALLOW FWD   172.17.0.2
 
-192.168.2.0/24/tcp         ALLOW FWD   172.17.0.2/tcp     <= this entry allow outgoing traffic to 192.168.2.0/24 subnet for all port tcp and udp
+192.168.2.0/24             ALLOW FWD   172.17.0.2         <= this entry allow outgoing traffic to 192.168.2.0/24 subnet for all tcp and udp ports
+192.168.3.0/24/tcp         ALLOW FWD   172.17.0.2/tcp     <= this entry allow outgoing traffic to 192.168.3.0/24 subnet for all tcp ports
 
 Anywhere                   DENY FWD    172.17.0.2         <= this entry block any other outgoing requests
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ services:
       - UFW_MANAGED=true
       - UFW_ALLOW_FROM=192.168.0.0/24
       - UFW_DENY_OUTGOING=true
-      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24
+      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24:tcp
     ports:
       - 80:80
 ```
@@ -213,7 +213,7 @@ To                         Action      From
 151.101.64.204 80/tcp      ALLOW FWD   172.17.0.2         <= to enable apt update in the container
 151.101.128.204 80/tcp     ALLOW FWD   172.17.0.2
 
-192.168.2.0/24             ALLOW FWD   172.17.0.2         <= this entry allow outgoing traffic to 192.168.2.0/24 subnet for all port tcp and udp
+192.168.2.0/24/tcp         ALLOW FWD   172.17.0.2/tcp     <= this entry allow outgoing traffic to 192.168.2.0/24 subnet for all port tcp and udp
 
 Anywhere                   DENY FWD    172.17.0.2         <= this entry block any other outgoing requests
 ```

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ Requires=ufw.service
 [Service]
 # Script requires run as root or sudo user to manage ufw!
 User=root
+Environment=PYTHONUNBUFFERED=1
 # Path to your python executable and actual location of the script
-ExecStart=/usr/bin/python3 /home/ubuntu/ufw-docker-automated.py
+ExecStart=/usr/bin/python3 -u /home/ubuntu/ufw-docker-automated.py
 Restart=always
 
 [Install]

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ To                         Action      From
 443/tcp                    ALLOW       Anywhere
 ```
 
-**Step 7**. Hardening firewall rules with UFW_FROM
+**Step 7**. Hardening firewall rules with UFW_ALLOW_FROM
 
 You can choose to restrict incoming traffic from specific IPs or Subnets.
 For example :
 
 ```
-➜  docker run -d -p 8080:80 -l UFW_MANAGED=TRUE -l "UFW_FROM=192.168.0.2;192.168.1.0/24" nginx:alpine
+➜  docker run -d -p 8080:80 -l UFW_MANAGED=TRUE -l "UFW_ALLOW_FROM=192.168.0.2;192.168.1.0/24" nginx:alpine
 13a6ef724d92f404f150f5796dabfd305f4e16a9de846a67e5e99ba53ed2e4e7
 ```
 
@@ -170,7 +170,7 @@ To                         Action      From
 172.17.0.2 80/tcp          ALLOW FWD   192.168.1.0/24  <= this baby added allowing only 192.168.1.0/24 to access nginx server 
 ```
 
-**Step 8**. Hardening firewall rules with UFW_DENY_OUTGOING and UFW_TO
+**Step 8**. Hardening firewall rules with UFW_DENY_OUTGOING and UFW_ALLOW_TO
 
 You can also choose to retrict outgoing traffic from specific IPs, Subnets or hostnames*.
 For example with docker-compose :
@@ -183,9 +183,9 @@ services:
     container_name: nginx
     labels:
       - UFW_MANAGED=true
-      - UFW_FROM=192.168.0.0/24
+      - UFW_ALLOW_FROM=192.168.0.0/24
       - UFW_DENY_OUTGOING=true
-      - UFW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24
+      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24
     ports:
       - 80:80
 ```

--- a/src/ufw-docker-automated.py
+++ b/src/ufw-docker-automated.py
@@ -107,7 +107,7 @@ def manage_ufw():
 
             if 'UFW_ALLOW_FROM' in container.labels:
                 try:
-                    ufw_allow_from = [ip_network(ipnet) for ipnet in container.labels.get('UFW_ALLOW_FROM').split(';')]
+                    ufw_allow_from = [ip_network(ipnet) for ipnet in container.labels.get('UFW_ALLOW_FROM').split(';') if ipnet]
                 except ValueError as e:
                     print(f"ufw-docker-automated: Invalid UFW label: UFW_ALLOW_FROM={container.labels.get('UFW_ALLOW_FROM')} exception={e}")
                     ufw_allow_from = -1
@@ -124,7 +124,7 @@ def manage_ufw():
                         if len(item_split) == 2 or len(item_split) == 1:
                             ipnet_list = validate_ipnet(ipnet=item_split.get(0))
                             port_dict = validate_port(port=item_split.get(1))
-                            ufw_allow_to += [{**ipnet_dict, **port_dict} for ipnet_dict in ipnet_list]
+                            ufw_allow_to += [{**ipnet_dict, **port_dict} for ipnet_dict in ipnet_list if ipnet_dict]
                 except ValueError as e:
                     print(f"ufw-docker-automated: Invalid UFW label: UFW_ALLOW_TO={container.labels.get('UFW_ALLOW_TO')} exception={e}")
                     ufw_allow_to = None

--- a/src/ufw-docker-automated.py
+++ b/src/ufw-docker-automated.py
@@ -2,75 +2,9 @@
 import subprocess
 import docker
 from ipaddress import ip_network
-import re
 
 client = docker.from_env()
 
-# implementation of a get method ontop __builtins__.list class
-class _list(__builtins__.list):
-    def get(self, index, default=None):
-        try:
-            return self[index] if self[index] else default
-        except IndexError:
-            return default
-
-def to_string_port(port):
-    if port.get(0) and port.get(1):
-        return f"on port {int(port.get(0))}/{port.get(1)}"
-    elif port.get(0):
-        return f"on port {int(port.get(0))}"
-    elif port.get(1):
-        return f"on proto {port.get(1)}"
-    else:
-        return ""
-
-def validate_port(port):
-    if not port:
-        return {}
-    r = re.compile('^(\d+)?((/|^)(tcp|udp))?$')
-    if r.match(port) is None:
-        raise ValueError(f"'{port}' does not appear to be a valid port and protocol that matches '^(\d+)?((/|^)(tcp|udp))?$'")
-    if port in ['tcp', 'udp']:
-        return {'protocol': port, 'to_string_port': to_string_port(_list([None, port]))}
-    port_and_protocol_split = _list(port.split('/'))
-    if not (1 <= int(port_and_protocol_split.get(0)) <= 65535):
-        raise ValueError(f"'{port}' does not appear to be a valid port number")
-    return {'port': int(port_and_protocol_split.get(0)), 'protocol': port_and_protocol_split.get(1), 'to_string_port': to_string_port(port_and_protocol_split)}
-
-def validate_hostname(hostname):
-    if len(hostname) > 255:
-        return False
-    if hostname[-1] == ".":
-        hostname = hostname[:-1] # strip exactly one dot from the right, if present
-    labels = hostname.split(".")
-    # the TLD must be not all-numeric
-    if re.match(r"[0-9]+$", labels[-1]):
-        return False
-    allowed = re.compile("(?!-)[A-Z\d\-_]{1,63}(?<!-)$", re.IGNORECASE)
-    return all(allowed.match(x) for x in labels)
-
-def validate_ip_network(ipnet):
-    try:
-        ip_network(ipnet)
-        return True
-    except ValueError as e:
-        return False
-
-# ipnet stands for ip or subnet
-def validate_ipnet(ipnet):
-    if not ipnet:
-        return [{}]
-    elif ipnet == "any":
-        return [{'ipnet': "any"}]
-    elif not validate_ip_network(ipnet=ipnet) and validate_hostname(hostname=ipnet):
-        host_output = subprocess.run([f"host -t a {ipnet}"],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
-                                shell=True).stdout.strip().split("\n")
-        if "not found:" in _list(host_output).get(0, ''):
-            print(f"ufw-docker-automated: Warning UFW label: {host_output[0]}")
-        return [{'ipnet': ip_network(_list(line.split("has address")).get(1).strip())} for line in host_output if _list(line.split("has address")).get(1)]
-    else:
-        return [{'ipnet': ip_network(ipnet)}]
 
 def manage_ufw():
     for event in client.events(decode=True):
@@ -89,9 +23,9 @@ def manage_ufw():
             container_port_num = None
             container_port_protocol = None
             ufw_managed = None
-            ufw_allow_from = None
+            ufw_from = ["any"]
             ufw_deny_outgoing = None
-            ufw_allow_to = None
+            ufw_to = None
 
             container_port_dict = container.attrs['NetworkSettings']['Ports'].items()
 
@@ -105,60 +39,33 @@ def manage_ufw():
             if 'UFW_MANAGED' in container.labels:
                 ufw_managed = container.labels.get('UFW_MANAGED').capitalize()
 
-            if 'UFW_ALLOW_FROM' in container.labels:
-                try:
-                    ufw_allow_from = [ip_network(ipnet) for ipnet in container.labels.get('UFW_ALLOW_FROM').split(';') if ipnet]
-                except ValueError as e:
-                    print(f"ufw-docker-automated: Invalid UFW label: UFW_ALLOW_FROM={container.labels.get('UFW_ALLOW_FROM')} exception={e}")
-                    ufw_allow_from = -1
-                    pass
-
-            if 'UFW_DENY_OUTGOING' in container.labels:
-                ufw_deny_outgoing = container.labels.get('UFW_DENY_OUTGOING').capitalize()
-
-            if 'UFW_ALLOW_TO' in container.labels:
-                try:
-                    ufw_allow_to = []
-                    for item in container.labels.get('UFW_ALLOW_TO').split(';'):
-                        item_split = _list(item.split(':'))
-                        if len(item_split) == 2 or len(item_split) == 1:
-                            ipnet_list = validate_ipnet(ipnet=item_split.get(0))
-                            port_dict = validate_port(port=item_split.get(1))
-                            ufw_allow_to += [{**ipnet_dict, **port_dict} for ipnet_dict in ipnet_list if ipnet_dict]
-                except ValueError as e:
-                    print(f"ufw-docker-automated: Invalid UFW label: UFW_ALLOW_TO={container.labels.get('UFW_ALLOW_TO')} exception={e}")
-                    ufw_allow_to = None
-                    pass
-
             if ufw_managed == 'True':
-                for key, value in container_port_dict:
-                    if value:
-                        container_port_num = list(key.split("/"))[0]
-                        container_port_protocol = list(key.split("/"))[1]
+                if 'UFW_FROM' in container.labels:
+                    try:
+                        ufw_from = [ip_network(ipnet) for ipnet in container.labels.get('UFW_FROM').split(';') if ipnet]
+                    except ValueError as e:
+                        print(f"ufw-docker-automated: Invalid UFW label: UFW_FROM={container.labels.get('UFW_FROM')} exception={e}")
+                        ufw_from = None
+                        pass
+
+                if 'UFW_DENY_OUTGOING' in container.labels:
+                    ufw_deny_outgoing = container.labels.get('UFW_DENY_OUTGOING').capitalize()
+
+                if ufw_deny_outgoing == 'True' and 'UFW_TO' in container.labels:
+                    try:
+                        ufw_to = [ip_network(ipnet) for ipnet in container.labels.get('UFW_TO').split(';') if ipnet]
+                    except ValueError as e:
+                        print(f"ufw-docker-automated: Invalid UFW label: UFW_TO={container.labels.get('UFW_TO')} exception={e}")
+                        ufw_to = None
+                        pass
 
             if event_type == 'start' and ufw_managed == 'True':
                 for key, value in container_port_dict:
                     if value:
                         container_port_num = list(key.split("/"))[0]
                         container_port_protocol = list(key.split("/"))[1]
-                        if not ufw_allow_from:
-                            # Allow incomming requests from any to the container
-                            print(f"ufw-docker-automated: Adding UFW rule: allow from any to container {container.name} on port {container_port_num}/{container_port_protocol}")
-                            subprocess.run([f"ufw route allow proto {container_port_protocol} \
-                                                from any \
-                                                to {container_ip} port {container_port_num}"],
-                                           stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
-                                           shell=True)
-                            if ufw_deny_outgoing == 'True':
-                                # Allow the container to reply back to any client (if outgoing requests are denied by default)
-                                print(f"ufw-docker-automated: Adding UFW rule: allow reply from container {container.name} on port {container_port_num}/{container_port_protocol} to any")
-                                subprocess.run([f"ufw route allow proto {container_port_protocol} \
-                                                    from {container_ip} port {container_port_num} \
-                                                    to any"],
-                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
-                                            shell=True)
-                        elif isinstance(ufw_allow_from, list):
-                            for source in ufw_allow_from:
+                        if ufw_from:
+                            for source in ufw_from:
                                 # Allow incomming requests from whitelisted IPs or Subnets to the container
                                 print(f"ufw-docker-automated: Adding UFW rule: allow from {source} to container {container.name} on port {container_port_num}/{container_port_protocol}")
                                 subprocess.run([f"ufw route allow proto {container_port_protocol} \
@@ -176,15 +83,11 @@ def manage_ufw():
                                                 shell=True)
 
                 if ufw_deny_outgoing == 'True':
-                    if ufw_allow_to:
-                        for destination in ufw_allow_to:
+                    if ufw_to:
+                        for destination in ufw_to:
                             # Allow outgoing requests from the container to whitelisted IPs or Subnets
-                            print(f"ufw-docker-automated: Adding UFW rule: allow outgoing from container {container.name} to {destination.get('ipnet')} {destination.get('to_string_port', '')}")
-                            destination_port = f"port {destination.get('port')}" if destination.get('port') else ""
-                            destination_protocol = f"proto {destination.get('protocol')}" if destination.get('protocol') else ""
-                            subprocess.run([f"ufw route allow {destination_protocol} \
-                                                from {container_ip} \
-                                                to {destination.get('ipnet')} {destination_port}"],
+                            print(f"ufw-docker-automated: Adding UFW rule: allow outgoing from container {container.name} to {destination}")
+                            subprocess.run([f"ufw route allow from {container_ip} to {destination}"],
                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                         shell=True)
                     # Deny any other outgoing requests
@@ -208,10 +111,11 @@ def manage_ufw():
 
                     # Removing any ufw rules that contains the container ip in it
                     ufw_num = ufw_status.stdout.strip().split("\n")[0]
-                    print(f"ufw-docker-automated: Cleaning UFW rule: for container {container.name}")
                     ufw_delete = subprocess.run([f"yes y | ufw delete {ufw_num}"],
                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                             shell=True)
+                    ufw_delete_result = ufw_delete.stdout.split("\n")[1].strip()
+                    print(f"ufw-docker-automated: Cleaning UFW rule: deleted rule '{ufw_delete_result}' for container {container.name}")
 
 
 if __name__ == '__main__':

--- a/src/ufw-docker-automated.py
+++ b/src/ufw-docker-automated.py
@@ -66,6 +66,8 @@ def validate_ipnet(ipnet):
         host_output = subprocess.run([f"host -t a {ipnet}"],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                 shell=True).stdout.strip().split("\n")
+        if "not found:" in _list(host_output).get(0, ''):
+            print(f"ufw-docker-automated: Warning UFW label: {host_output[0]}")
         return [{'ipnet': ip_network(_list(line.split("has address")).get(1).strip())} for line in host_output if _list(line.split("has address")).get(1)]
     else:
         return [{'ipnet': ip_network(ipnet)}]
@@ -177,7 +179,7 @@ def manage_ufw():
                     if ufw_allow_to:
                         for destination in ufw_allow_to:
                             # Allow outgoing requests from the container to whitelisted IPs or Subnets
-                            print(f"ufw-docker-automated: Adding UFW rule: allow outgoing from container {container.name} to {destination.get('ipnet')} {destination.get('to_string_port')}")
+                            print(f"ufw-docker-automated: Adding UFW rule: allow outgoing from container {container.name} to {destination.get('ipnet')} {destination.get('to_string_port', '')}")
                             destination_port = f"port {destination.get('port')}" if destination.get('port') else ""
                             destination_protocol = f"proto {destination.get('protocol')}" if destination.get('protocol') else ""
                             subprocess.run([f"ufw route allow {destination_protocol} \

--- a/src/ufw-docker-automated.py
+++ b/src/ufw-docker-automated.py
@@ -2,9 +2,74 @@
 import subprocess
 import docker
 from ipaddress import ip_network
+import re
 
 client = docker.from_env()
 
+class _list(__builtins__.list):
+    def get(self, index, default=None):
+        try:
+            return self[index] if self[index] else default
+        except IndexError:
+            return default
+
+class _tuple(__builtins__.tuple):
+    def get(self, index, default=None):
+        try:
+            return self[index] if self[index] else default
+        except IndexError:
+            return default
+
+def validate_port(port):
+    if not port:
+        return _tuple([None, None])
+
+    _port = str(port)
+    r = re.compile('^(\d+)?(/tcp|/udp)?$')
+    if r.match(_port) is None:
+        raise ValueError(f"Port format is invalid {_port} it must match '^(\d+)?(/tcp|/udp)?$'")
+    _port_tuple = _list(_port.split('/'))
+    return _tuple([_port_tuple.get(0), _port_tuple.get(1)])
+
+def validate_hostname(hostname):
+    if len(hostname) > 255:
+        return False
+    if hostname[-1] == ".":
+        hostname = hostname[:-1] # strip exactly one dot from the right, if present
+    allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    return all(allowed.match(x) for x in hostname.split("."))
+
+def validate_ip_network(ip):
+    try:
+        ip_network(ip)
+        return True
+    except ValueError as e:
+        return False
+
+def validate_network(network):
+    if not network:
+        return _list()
+
+    _network = str(network)
+    if _network == "any":
+        return _list(["any"])
+    elif not validate_ip_network(_network) and validate_hostname(_network):
+        host_output = subprocess.run([f"host -t a {_network}"],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
+                    shell=True).stdout.strip().split("\n")
+        return _list([ip_network(_list(line.split("has address")).get(1).strip()) for line in host_output if _list(line.split("has address")).get(1)])
+    else:
+        return _list([ip_network(_network)])
+
+def format_destination_port(_to):
+    if _to.get(1) and _to.get(2):
+        return f" on port {_to.get(1)}/{_to.get(2)}"
+    elif _to.get(1):
+        return f" on port {_to.get(1)}"
+    elif _to.get(2):
+        return f" on proto {_to.get(2)}"
+    else:
+        return ""
 
 def manage_ufw():
     for event in client.events(decode=True):
@@ -24,6 +89,8 @@ def manage_ufw():
             container_port_protocol = None
             ufw_managed = None
             ufw_from = None
+            ufw_deny_outgoing = None
+            ufw_to = None
 
             container_port_dict = container.attrs['NetworkSettings']['Ports'].items()
 
@@ -44,7 +111,24 @@ def manage_ufw():
                     print(f"Invalid UFW label: UFW_FROM={container.labels.get('UFW_FROM')} exception={e}")
                     ufw_from = -1
                     pass
-                          
+
+            if 'UFW_DENY_OUTGOING' in container.labels:
+                ufw_deny_outgoing = container.labels.get('UFW_DENY_OUTGOING').capitalize()
+
+            if 'UFW_TO' in container.labels:
+                try:
+                    ufw_to = _list()
+                    for _to in container.labels.get('UFW_TO').split(';'):
+                        _to_list = _list(_to.split(':'))
+                        if len(_to_list) == 2 or len(_to_list) == 1:
+                            _to_sub = validate_network(_to_list.get(0))
+                            _to_port = validate_port(_to_list.get(1))
+                            ufw_to += [_tuple([_ip, _to_port.get(0), _to_port.get(1)]) for _ip in _to_sub]
+                except ValueError as e:
+                    print(f"ufw-docker-automated: Invalid UFW label: UFW_TO={container.labels.get('UFW_TO')} exception={e}")
+                    ufw_to = None
+                    pass
+
             if ufw_managed == 'True':
                 for key, value in container_port_dict:
                     if value:
@@ -57,20 +141,50 @@ def manage_ufw():
                         container_port_num = list(key.split("/"))[0]
                         container_port_protocol = list(key.split("/"))[1]
                         if not ufw_from:
-                            print(f"Adding UFW rule: {container_port_num}/{container_port_protocol} of container {container.name}")
+                            print(f"Adding UFW rule: allow from any to container {container.name} on port {container_port_num}/{container_port_protocol}")
                             subprocess.run([f"sudo ufw route allow proto {container_port_protocol} \
                                                 from any to {container_ip} \
                                                 port {container_port_num}"],
                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                            shell=True)
+                            if ufw_deny_outgoing == 'True':
+                                # Allow container to reply back to the client
+                                print(f"Adding UFW rule: allow reply from container {container.name} on port {container_port_num}/{container_port_protocol} to any")
+                                subprocess.run([f"ufw route allow proto {container_port_protocol} \
+                                                    from {container_ip} port {container_port_num} to any"],
+                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
+                                            shell=True)
                         elif isinstance(ufw_from, list):
                             for subnet in ufw_from:
-                                print(f"Adding UFW rule: {container_port_num}/{container_port_protocol} of container {container.name} from {subnet}")
+                                print(f"Adding UFW rule: allow from {subnet} to container {container.name} on port {container_port_num}/{container_port_protocol}")
                                 subprocess.run([f"sudo ufw route allow proto {container_port_protocol} \
                                                     from {subnet} to {container_ip} \
                                                     port {container_port_num}"],
                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                             shell=True)
+                                if ufw_deny_outgoing == 'True':
+                                    # Allow container to reply back to the client
+                                    print(f"Adding UFW rule: allow reply from container {container.name} on port {container_port_num}/{container_port_protocol} to {subnet}")
+                                    subprocess.run([f"ufw route allow proto {container_port_protocol} \
+                                                        from {container_ip} port {container_port_num} to {subnet}"],
+                                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
+                                                shell=True)
+
+                if ufw_deny_outgoing == 'True':
+                    if ufw_to:
+                        for _to in ufw_to:
+                            print(f"Adding UFW rule: allow outgoing from container {container.name} to {_to.get(0)}{format_destination_port(_to)}")
+                            destination_port_num = f"port {_to.get(1)}" if _to.get(1) else ""
+                            destination_port_protocol = f"proto {_to.get(2)}" if _to.get(2) else ""
+                            subprocess.run([f"ufw route allow {destination_port_protocol} \
+                                                from {container_ip} to {_to.get(0)} {destination_port_num}"],
+                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
+                                        shell=True)
+                    # Deny any other outgoing requests
+                    print(f"Adding UFW rule: deny outgoing from container {container.name} to any")
+                    subprocess.run([f"ufw route deny from {container_ip} to any"],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
+                                shell=True)
 
             if event_type == 'kill' and ufw_managed == 'True':
                 ufw_length = subprocess.run(
@@ -86,7 +200,7 @@ def manage_ufw():
                         shell=True)
 
                     ufw_num = ufw_status.stdout.strip().split("\n")[0]
-                    print(f"Cleaning UFW rule: {container_port_num}/{container_port_protocol} of container {container.name}")
+                    print(f"Cleaning UFW rule: for container {container.name}")
                     ufw_delete = subprocess.run([f"yes y | sudo ufw delete {ufw_num}"],
                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                             shell=True)


### PR DESCRIPTION
Since this feature is already implemented and seems to work during my tests. I think it's better to implement the #5 feature before #4. I renamed labels as discussed in the last [PR](https://github.com/shinebayar-g/ufw-docker-automated/pull/3).

Example : 
```
version: '2.4'
services:
  nginx:
    image: nginx:alpine
    container_name: nginx
    labels:
      - UFW_MANAGED=true
      - UFW_ALLOW_FROM=192.168.0.0/24
      - UFW_DENY_OUTGOING=true
      - UFW_ALLOW_TO=any:53;deb.debian.org:80/tcp;security.debian.org:80/tcp;192.168.2.0/24;192.168.3.0/24:tcp
    ports:
      - 80:80
```

I also add some modifications : remove sudo in ufw commands, modify prints*, add some validation methods**. Let me know if those suggestions work for you.

*I added `ufw-docker-automated: ` prefix to easily find logs in syslog file using the command `sudo cat /var/log/syslog | grep ufw-docker-automated`
**For hostname validation the source is [https://stackoverflow.com/questions/2532053/validate-a-hostname-string](https://stackoverflow.com/questions/2532053/validate-a-hostname-string). hostname validation is a mess so we'll be a bit more permissive (example with underscores), and if the hostname is not resolved no ufw rules will be added. In this case, RFC feels like the bible there's different interpretations.