### PR TITLE
Implemented Multi docker network and connection

### DIFF
--- a/ufwhandler/delete.go
+++ b/ufwhandler/delete.go
@@ -15,55 +15,61 @@ func DeleteUfwRule(containerID <-chan string, c *cache.Cache) {
 			container := cachedContainer.(*TrackedContainer)
 			// Handle inbound rules
 			for _, rule := range container.UfwInboundRules {
-				cmd := exec.Command("sudo", "ufw", "route", "delete", "allow", "proto", rule.Proto, "from", rule.CIDR, "to", container.IPAddress, "port", rule.Port, "comment", container.Name+":"+id+rule.Comment)
-				log.Info().Msg("ufw-docker-automated: Deleting inbound rule: " + cmd.String())
+				for dnetwork, containerIP := range container.IPAddressMap {
+					cmd := exec.Command("sudo", "ufw", "route", "delete", "allow", "proto", rule.Proto, "from", rule.CIDR, "to", containerIP, "port", rule.Port, "comment", container.Name+":"+id+rule.Comment)
+					log.Info().Msg("ufw-docker-automated: Deleting inbound rule (docker network :" + dnetwork + "): " + cmd.String())
 
-				var stdout, stderr bytes.Buffer
-				cmd.Stdout = &stdout
-				cmd.Stderr = &stderr
-				err := cmd.Run()
+					var stdout, stderr bytes.Buffer
+					cmd.Stdout = &stdout
+					cmd.Stderr = &stderr
+					err := cmd.Run()
 
-				if err != nil || stderr.String() != "" {
-					log.Error().Err(err).Msg("ufw error: " + stderr.String())
-				} else {
-					log.Info().Msg("ufw: " + stdout.String())
+					if err != nil || stderr.String() != "" {
+						log.Error().Err(err).Msg("ufw error: " + stderr.String())
+					} else {
+						log.Info().Msg("ufw: " + stdout.String())
+					}
 				}
 			}
 			// Handle outbound rules
 			for _, rule := range container.UfwOutboundRules {
-				var cmd *exec.Cmd
-				if rule.Port == "" {
-					cmd = exec.Command("sudo", "ufw", "route", "delete", "allow", "from", container.IPAddress, "to", rule.CIDR, "comment", container.Name+":"+id+rule.Comment)
-				} else {
-					cmd = exec.Command("sudo", "ufw", "route", "delete", "allow", "from", container.IPAddress, "to", rule.CIDR, "port", rule.Port, "comment", container.Name+":"+id+rule.Comment)
-				}
-				log.Info().Msg("ufw-docker-automated: Deleting outbound rule: " + cmd.String())
+				for dnetwork, containerIP := range container.IPAddressMap {
+					var cmd *exec.Cmd
+					if rule.Port == "" {
+						cmd = exec.Command("sudo", "ufw", "route", "delete", "allow", "from", containerIP, "to", rule.CIDR, "comment", container.Name+":"+id+rule.Comment)
+					} else {
+						cmd = exec.Command("sudo", "ufw", "route", "delete", "allow", "from", containerIP, "to", rule.CIDR, "port", rule.Port, "comment", container.Name+":"+id+rule.Comment)
+					}
+					log.Info().Msg("ufw-docker-automated: Deleting outbound rule (docker network :" + dnetwork + "): " + cmd.String())
 
-				var stdout, stderr bytes.Buffer
-				cmd.Stdout = &stdout
-				cmd.Stderr = &stderr
-				err := cmd.Run()
+					var stdout, stderr bytes.Buffer
+					cmd.Stdout = &stdout
+					cmd.Stderr = &stderr
+					err := cmd.Run()
 
-				if err != nil || stderr.String() != "" {
-					log.Error().Err(err).Msg("ufw error: " + stderr.String())
-				} else {
-					log.Info().Msg("ufw: " + stdout.String())
+					if err != nil || stderr.String() != "" {
+						log.Error().Err(err).Msg("ufw error: " + stderr.String())
+					} else {
+						log.Info().Msg("ufw: " + stdout.String())
+					}
 				}
 			}
 			// Handle deny all out
 			if container.Labels["UFW_DENY_OUT"] == "TRUE" {
-				cmd := exec.Command("sudo", "ufw", "route", "delete", "deny", "from", container.IPAddress, "to", "any", "comment", container.Name+":"+id)
-				log.Info().Msg("ufw-docker-automated: Deleting outbound rule: " + cmd.String())
+				for dnetwork, containerIP := range container.IPAddressMap {
+					cmd := exec.Command("sudo", "ufw", "route", "delete", "deny", "from", containerIP, "to", "any", "comment", container.Name+":"+id)
+					log.Info().Msg("ufw-docker-automated: Deleting outbound rule (docker network :" + dnetwork + "): " + cmd.String())
 
-				var stdout, stderr bytes.Buffer
-				cmd.Stdout = &stdout
-				cmd.Stderr = &stderr
-				err := cmd.Run()
+					var stdout, stderr bytes.Buffer
+					cmd.Stdout = &stdout
+					cmd.Stderr = &stderr
+					err := cmd.Run()
 
-				if err != nil || stderr.String() != "" {
-					log.Error().Err(err).Msg("ufw error: " + stderr.String())
-				} else {
-					log.Info().Msg("ufw: " + stdout.String())
+					if err != nil || stderr.String() != "" {
+						log.Error().Err(err).Msg("ufw error: " + stderr.String())
+					} else {
+						log.Info().Msg("ufw: " + stdout.String())
+					}
 				}
 			}
 		} else {

--- a/ufwhandler/types.go
+++ b/ufwhandler/types.go
@@ -2,7 +2,7 @@ package ufwhandler
 
 type TrackedContainer struct {
 	Name             string
-	IPAddress        string
+	IPAddressMap     map[string]string
 	Labels           map[string]string
 	UfwInboundRules  []UfwRule
 	UfwOutboundRules []UfwRule


### PR DESCRIPTION
# What
Implements Multi-Network mode in docker-compose.

# Closes

Fixes #44

# Tests
Tested multi-network using the following `docker-compose.yaml`

```yaml
version: '3.9'

networks:
  nginx_net:
    driver: bridge
    name: nginx_net
    ipam:
      config:
        - subnet: 172.84.0.0/16
          gateway: 172.84.0.1
  k3d-ext: # Test an external network
    name: k3d
    external: true

services:
  nginx:
    container_name: nginx
    image: nginx:latest
    ports:
      - 8800:80
      - 2120:8000
    networks:
      - nginx_net
      - k3d-ext
    labels:
      - "UFW_MANAGED=TRUE"
```

# Sample Log from `systemd`

```log
May 10 18:33:03 chromebox ufw-docker-automated[11836]: 2023-05-10T18:33:03-07:00 INF main.go:18 > ufw-docker-automated: Connected to the Docker Engine.
May 10 18:33:41 chromebox ufw-docker-automated[11836]: 2023-05-10T18:33:41-07:00 INF create.go:91 > ufw-docker-automated: Adding inbound rule: /usr/bin/sudo ufw route allow proto tcp from 10.110.210.179 to 192.168.151.3 port 80 comment traefik:e2dbe6de65a2
May 10 18:33:41 chromebox ufw-docker-automated[11836]: 2023-05-10T18:33:41-07:00 INF create.go:96 > ufw cmd (network: socket_proxy): /usr/bin/sudo ufw route allow proto tcp from 10.110.210.179 to 192.168.151.3 port 80 comment traefik:e2dbe6de65a2
May 10 18:33:41 chromebox ufw-docker-automated[11836]: 2023-05-10T18:33:41-07:00 INF create.go:91 > ufw-docker-automated: Adding inbound rule: /usr/bin/sudo ufw route allow proto tcp from 10.110.210.179 to 192.168.150.2 port 80 comment traefik:e2dbe6de65a2
May 10 18:33:41 chromebox ufw-docker-automated[11836]: 2023-05-10T18:33:41-07:00 INF create.go:96 > ufw cmd (network: t2_proxy): /usr/bin/sudo ufw route allow proto tcp from 10.110.210.179 to 192.168.150.2 port 80 comment traefik:e2dbe6de65a2
```