### PR TITLE
add an option to only ALLOW some ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ This project solves that problem by listening to the Docker API events.
 - Zero dependency, single binary installation
 - Supports docker-compose
 - Supports both inbound/outbound rules
+- Selectively allow only certain published ports
 
 ## Supported labels
 
-| Label key      | Value / Syntax                                                   | Example                                                     |
-| -------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
-| UFW_MANAGED    | TRUE _(Required for all rules)_                                  | `-l UFW_MANAGED=TRUE`                                       |
-| UFW_ALLOW_FROM | CIDR/IP-SpecificPort-Comment , Semicolon separated, default=any  | `-l UFW_ALLOW_FROM=192.168.3.0/24-LAN;10.10.0.50/32-53-DNS` |
-| UFW_DENY_OUT   | TRUE _(Required if outbound rules are defined)_                  | `-l UFW_DENY_OUT=TRUE`                                      |
-| UFW_ALLOW_TO   | CIDR/IP-SpecificPort-Comment , Semicolon separated, default=none | `-l UFW_ALLOW_TO=192.168.3.0/24-LAN;10.10.0.50/32-53-DNS`   |
+| Label key        | Value / Syntax                                                   | Example                                                     |
+| --------------   | ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| UFW_MANAGED      | TRUE _(Required for all rules)_                                  | `-l UFW_MANAGED=TRUE`                                       |
+| UFW_ALLOW_FROM   | CIDR/IP-SpecificPort-Comment , Semicolon separated, default=any  | `-l UFW_ALLOW_FROM=192.168.3.0/24-LAN;10.10.0.50/32-53-DNS` |
+| UFW_DENY_OUT     | TRUE _(Required if outbound rules are defined)_                  | `-l UFW_DENY_OUT=TRUE`                                      |
+| UFW_ALLOW_TO     | CIDR/IP-SpecificPort-Comment , Semicolon separated, default=none | `-l UFW_ALLOW_TO=192.168.3.0/24-LAN;10.10.0.50/32-53-DNS`   |
+| UFW_IGNORE_PORTS | Container port, Semicolon separated, default=none                | `-l UFW_IGNORE_PORTS=22;80`                                 |
 
 ## Example
 
@@ -39,11 +41,13 @@ services:
     ports:
       - '8080:80'
       - '8081:81'
+      - '8082:82'
     labels:
       UFW_MANAGED: 'TRUE'
       UFW_ALLOW_FROM: '172.10.50.32;192.168.3.0/24;10.10.0.50/32-8080-LAN'
       UFW_DENY_OUT: 'TRUE'
       UFW_ALLOW_TO: '8.8.8.8-53-GoogleDNS;1.1.1.0/24-53-CloudflareDNS;192.168.10.24-8080-LAN'
+      UFW_IGNORE_PORTS: '82'
     networks:
       - my-network
 

--- a/ufwhandler/create.go
+++ b/ufwhandler/create.go
@@ -46,7 +46,15 @@ func CreateUfwRule(ch <-chan *types.ContainerJSON, c *cache.Cache) {
 		c.Set(containerID, &cachedContainer, cache.NoExpiration)
 
 		// Handle inbound rules
+		inboundLoop:
 		for port, portMaps := range container.HostConfig.PortBindings {
+			// If port is in UFW_IGNORE_PORTS, leave it alone
+			for _, i := range strings.Split(container.Config.Labels["UFW_IGNORE_PORTS"], ";") {
+				if i == port.Port() {
+					continue inboundLoop
+				}
+			}
+
 			// List is non empty if port is published
 			if len(portMaps) > 0 {
 				ufwRules := []UfwRule{}


### PR DESCRIPTION
This allows you to expose ports from the same container both to the world and to only localhost. For example, you can open Gitlab's SSH port, but keep its `:80` private for your reverse proxy. (Yes I know I should be using docker networking instead of localhost it's complicated)